### PR TITLE
add explanation of price_min and price_max attrs in journals/list api.

### DIFF
--- a/README-j.md
+++ b/README-j.md
@@ -1439,7 +1439,8 @@ Parameters:
 Parameter | Necessity | Type | Description
 --- | --- | --- | ---
 `id` | *optional* | String | idで検索します。
-`price` | *optional* | String | 金額で検索します。税抜き金額か税込金額のどちらかに一致したレコードを返します。
+`price_min` | *optional* | String | 金額で検索します。税抜金額が指定した金額以上の仕訳を検索します。
+`price_max` | *optional* | String | 金額で検索します。税抜金額が指定した金額以下の仕訳を検索します。
 `memo` | *optional* | String | メモに書かれてある内容で部分検索します。
 `dept_code` | *optional* | String | 部門コードで検索します。
 `tag_list` | *optional* | String | セグメント(旧タグ)で検索します。

--- a/README-j.md
+++ b/README-j.md
@@ -1439,8 +1439,8 @@ Parameters:
 Parameter | Necessity | Type | Description
 --- | --- | --- | ---
 `id` | *optional* | String | idで検索します。
-`price_min` | *optional* | String | 金額で検索します。税抜金額が指定した金額以上の仕訳を検索します。
-`price_max` | *optional* | String | 金額で検索します。税抜金額が指定した金額以下の仕訳を検索します。
+`price_min` | *optional* | Integer | 金額で検索します。税抜金額、または税額が指定した金額以上の科目を含む仕訳を検索します。
+`price_max` | *optional* | Integer | 金額で検索します。税抜金額、または税額が指定した金額以下の科目を含む仕訳を検索します。
 `memo` | *optional* | String | メモに書かれてある内容で部分検索します。
 `dept_code` | *optional* | String | 部門コードで検索します。
 `tag_list` | *optional* | String | セグメント(旧タグ)で検索します。

--- a/README.md
+++ b/README.md
@@ -1497,8 +1497,8 @@ Parameters:
 Parameter | Necessity | Type | Description
 --- | --- | --- | ---
 `id` | *optional* | String | Search using the journal id directly.
-`price_min` | *optional* | String | Search for journals which amount is larger than specific price. Matching journals will be returned if price excluding tax is greater than or equal to the specified price.
-`price_max` | *optional* | String | Search for journals which amount is smaller than specific price. Matching journals will be returned if price excluding tax is smaller than or equals to specified price.
+`price_min` | *optional* | String | Search for journals which amount is larger than specific price. Matching journals will be returned if the journal includes account title which price excluding tax or tax price is greater than or equal to the specified price.
+`price_max` | *optional* | String | Search for journals which amount is smaller than specific price. Matching journals will be returned if the journal includes account title which price excluding tax or tax price is smaller than or equals to specified price.
 `memo` | *optional* | String | Search journals that contain the specified keywords in their memo.
 `dept_code` | *optional* | String | Search journals that belong to the specified department.
 `tag_list` | *optional* | String | Search for journals that have the specified segment(formerly tag).

--- a/README.md
+++ b/README.md
@@ -1497,7 +1497,8 @@ Parameters:
 Parameter | Necessity | Type | Description
 --- | --- | --- | ---
 `id` | *optional* | String | Search using the journal id directly.
-`price` | *optional* | String | Search for journals with the specified amount. Matching journals will be returned if either its price excluding tax or sales tax price match the specified price.
+`price_min` | *optional* | String | Search for journals which amount is larger than specific price. Matching journals will be returned if price excluding tax is greater than or equal to the specified price.
+`price_max` | *optional* | String | Search for journals which amount is smaller than specific price. Matching journals will be returned if price excluding tax is smaller than or equals to specified price.
 `memo` | *optional* | String | Search journals that contain the specified keywords in their memo.
 `dept_code` | *optional* | String | Search journals that belong to the specified department.
 `tag_list` | *optional* | String | Search for journals that have the specified segment(formerly tag).


### PR DESCRIPTION
仕訳帳検索のlist表示のリクエストを送る際の検索条件指定でprice_min, price_maxが追加され、代わりに、priceが廃止される予定なので、これをドキュメントに反映しました。

この変更は**API側の変更が完了されてからマージしてください。**