### PR TITLE
[update] DEFECT-1902 ERPの原因コードに入力条件を表示する

### DIFF
--- a/README-j.md
+++ b/README-j.md
@@ -2945,7 +2945,7 @@ Parameters:
 Parameter | Necessity | Type | Description
 --- | --- | --- | ---
 `sort_number` | *optional* | String | 並び順
-`reason_code` | *required* | String | 原因コード
+`reason_code` | *required* | String | 原因コード。半角英数字及びアンダーバー60文字以内。
 `reason_name` | *required* | String | 原因名
 `dc` | *required* | String | 入出金区分　'd' は debit の意で「増加」に、'c' は credit の意で「減少」になります。
 `is_valid` | *required* | Integer | 表示区分 2:マネージャのみ　1: 表示、0: 非表示
@@ -3112,7 +3112,7 @@ Parameters:
 Parameter | Necessity | Type | Description
 --- | --- | --- | ---
 `sort_no` | *optional* | Integer | 並び順
-`reason_code` | *required* | String | 原因コード
+`reason_code` | *required* | String | 原因コード。半角英数字及びアンダーバー60文字以内。
 `reason_name` | *required* | String | 原因名
 `dc` | *required* | Text | 入出金区分　d: 入金 c: 出金
 `account_code` | *required* | text | 勘定科目コード

--- a/README.md
+++ b/README.md
@@ -3001,7 +3001,7 @@ Parameters:
 Parameter | Necessity | Type | Description
 --- | --- | --- | ---
 `sort_number` | *optional* | String | Sort Number
-`reason_code` | *required* | String | Reason Code
+`reason_code` | *required* | String | Reason Code. Alphanumeric characters and underscores, up to 60 characters.
 `reason_name` | *required* | String | Reason of Bank Transaction
 `dc` | *required* | String | 'd' if the transaction was a debit, 'c' if it was a credit.
 `is_valid` | *required* | Integer | Display Status 2:Manager Only　1:able 、0: Disable
@@ -3168,7 +3168,7 @@ Parameters:
 Parameter | Necessity | Type | Description
 --- | --- | --- | ---
 `sort_no` | *optional* | Integer | Sort order
-`reason_code` | *required* | String | Reason code used for PettyCashTransaction
+`reason_code` | *required* | String | Reason code used for PettyCashTransaction. Alphanumeric characters and underscores, up to 60 characters.
 `reason_name` | *required* | String | Reason name used for PettyCashTransaction
 `dc` | *required* | Text | 'd' if the reason was a debit, 'c' if it was a credit
 `account_code` | *required* | text | Account code for the journal entry


### PR DESCRIPTION
-銀行原因マスタ作成、現金原因マスタ作成の引数一覧に、原因コードの入力制限についての説明を追加。